### PR TITLE
docs: fix Jetson spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you do not have LibTorch installed in system search paths, add one line befor
 
 **[Option 1] Conda**: If using Conda with compatible PyTorch:
 ```cmake
-# [For Jatson Orin] To install Pytorch in Jatson developer kit:
+# [For Jetson Orin] To install Pytorch in Jetson developer kit:
 # export TORCH_INSTALL=https://developer.download.nvidia.cn/compute/redist/jp/v511/pytorch/torch-2.0.0+nv23.05-cp38-cp38-linux_aarch64.whl
 # pip install --no-cache $TORCH_INSTALL
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `Jatson` to `Jetson` in the README edge-device section.

Fixes #10

## Test plan
- static validation: `Jatson` appeared 2 time(s) in `README.md` before replacement.
- static validation: `Jetson` is present in `README.md` after patch.
- static validation: `Jatson` is absent from `README.md` after patch.
- Not run: runtime test suite, because this is a small README/documentation typo fix.
